### PR TITLE
Fixed a bug for reading in files containing special characters on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Catalyst
 
-Catalyst contains scripts for scraping
-Alloy models from github, etc. and filtering these sets for particular characteristics.
+Catalyst contains scripts for scraping Alloy models from github, etc. and
+filtering these sets for particular characteristics.
 
 ## Using the Model Sets
 
-The directory "models-sets" will contain the created set of Alloy models (sometimes within the
-directory hierarchy they came with). Each directory
-is dated by the date is was created. The README.md file within with model set
+The directory "models-sets" will contain the created set of Alloy models (
+sometimes within the directory hierarchy they came with). Each directory is
+dated by the date is was created. The README.md file within with model set
 directory tells you what filters (programmatically or manually) to create this
 model set.
 
@@ -44,7 +44,10 @@ and filters you want to use to create a new model set.
 Extract a list of sat/unsat models, also find appropriate scopes which let
 solving time fall in a desired range. See
 src/main/java/alloymodeltools/ExtractModels.java and setting the model set
-directory you want to extract models in and other options.
+directory you want to extract models in and other options.  
+Note that for finding best scopes analysis it is Java timing Java and we have
+found that when running another time with python controlling the Java process
+the timing can vary significantly.
 
 ### Running the scripts
 
@@ -167,4 +170,6 @@ model
 
 ## Credits
 
-Catalyst was created by Ruomei Yan, Elias Eid, Amin Bandali, and Nancy A. Day at the University of Waterloo.  It is used by graduate students to create sets of Alloy models for study.
+Catalyst was created by Ruomei Yan, Elias Eid, Amin Bandali, and Nancy A. Day at
+the University of Waterloo. It is used by graduate students to create sets of
+Alloy models for study.

--- a/src/main/java/alloymodelsettools/ExtractModels.java
+++ b/src/main/java/alloymodelsettools/ExtractModels.java
@@ -37,7 +37,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 
 import edu.mit.csail.sdg.ast.Command;
@@ -340,7 +339,7 @@ public class ExtractModels {
             // Print files with new commands in sat and unsat directories
             Path path = file.toPath();
             Charset charset = StandardCharsets.UTF_8;
-            String content = FileUtils.readFileToString(file);
+            String content = Files.readString(path, charset);
             // Remove all comments
             content = content.replaceAll("//.*|--.*|/\\*[\\S\\s]*?\\*/", "");
             // Remove all commands using regular expression


### PR DESCRIPTION
2021-06-03-12-31-50/pvhxe62lowi55tmws6fmo7iajyjk2ap6-alloy-tutorial/alloy-analyzer/Approve2Step.als
The file actually has utf-8 encoding. It turns out that imported library org.apache.commons.io.FileUtils has inconsistent behaviour across different OS. It fails to read the file content into a string on Linux, but works fine on my machine(macOS).
I fixed this problem by switching from using FileUtils library to Files library. It now works with this file, but no guarantee it will work with all other encodings. 